### PR TITLE
move hosting from firebase to GCP

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ You will also see any lint errors in the console.
 
 ## Deploying
 
-First make sure you have the firebase cli (https://firebase.google.com/docs/cli/)
 
-Then build for production and deploy
+First build for production
 `yarn build`
 
-`firebase deploy`
+Then make sure you have the appropriate GCP permissions and use gcloud command line to deploy
+`gcloud config set project dtpr-mvp`
+`gcloud app deploy`
 
 
 The build step bundles React in production mode and optimizes the build for the best performance, and locates it in the `build` folder.

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,11 @@
+runtime: nodejs10
+service: default
+env: standard
+instance_class: F1
+handlers:
+  - url: /(.*\.(svg|gif|media|json|ico|eot|ttf|woff|woff2|png|jpg|css|js))$
+    static_files: build/\1
+    upload: build/(.*)
+  - url: /(.*)
+    static_files: build/index.html
+    upload: build/index.html

--- a/firebase.json
+++ b/firebase.json
@@ -2,20 +2,6 @@
   "database": {
     "rules": "database.rules.json"
   },
-  "hosting": {
-    "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
-  },
   "storage": {
     "rules": "storage.rules"
   }


### PR DESCRIPTION
move hosting from firebase to GCP so we can support the correct custom Google certs